### PR TITLE
Don't include trailing ".js" as part of module name

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ class ScreepsWebpackPlugin {
             return reject(err)
           }
 
-          const moduleName = path.basename(file)
+          const moduleName = path.parse(file).name
 
           resolve({[moduleName]: data})
         })

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ class ScreepsWebpackPlugin {
             return reject(err)
           }
 
-          const moduleName = path.parse(file).name
+          const moduleName = path.basename(file, '.js')
 
           resolve({[moduleName]: data})
         })


### PR DESCRIPTION
Original version required the webpack output file to be "main" in order to upload as module `main`, but this makes integrating with other webpack features frustrating.

This change allows files to have `.js` extensions (ex. `main.js`), while still uploading with module name `main`